### PR TITLE
Empty mapStateToProps

### DIFF
--- a/frontend/src/pages/homepage/components/location.js
+++ b/frontend/src/pages/homepage/components/location.js
@@ -7,9 +7,8 @@ import { connect } from 'react-redux'
 import TimeStamp from './time_stamp'
 import {} from '../actions'
 
-/*
-no dispatch to props without state to props possible
- */
+const mapStateToProps = null
+
 const mapDispatchToProps = dispatch => ({
 
 })
@@ -72,4 +71,4 @@ LocationItem.propTypes = {
   timeStamps: PropTypes.array.isRequired,
 }
 
-export default withStyles(styles)(connect(mapDispatchToProps)(LocationItem))
+export default withStyles(styles)(connect(mapStateToProps, mapDispatchToProps)(LocationItem))

--- a/frontend/src/pages/homepage/components/time_stamp.js
+++ b/frontend/src/pages/homepage/components/time_stamp.js
@@ -13,8 +13,7 @@ const myUser = {
   lastName: 'Nadoba',
 }
 
-// allway need mapstate to props, maybe some kind of default mapstate?
-const mapStateToProps = state => (state)
+const mapStateToProps = null
 
 const mapDispatchToProps = dispatch => ({
   addUserAction: (timeStampID, locationID, user) => {


### PR DESCRIPTION
Hi guys,

you can easily skip the `mapStateToProps` if you don't need it. I saw it a couple of times an empty `mapStateToProps` inside your code.

Example:
`export default withStyles(styles)(connect(mapStateToProps, mapDispatchToProps)(TimeStamp))`
==>
`export default withStyles(styles)(connect(null, mapDispatchToProps)(TimeStamp))`

Keep up the good work!